### PR TITLE
Add liquid stacking test (currently failing)

### DIFF
--- a/tests/item_test.cpp
+++ b/tests/item_test.cpp
@@ -167,6 +167,38 @@ TEST_CASE( "stacking_over_time", "[item]" )
     }
 }
 
+TEST_CASE( "liquids at different temperatures", "[item][temperature][stack][combine]" )
+{
+    item liquid_hot( "test_liquid" );
+    item liquid_cold( "test_liquid" );
+
+    // heat_up/cold_up sets temperature of item and corresponding HOT/COLD flags
+    liquid_hot.heat_up(); // 60 C (333.15 K)
+    liquid_cold.cold_up(); // 3 C (276.15 K)
+    // Temperature is in terms of 0.000001 K
+    REQUIRE( std::floor( liquid_hot.temperature / 100000 ) == 333 );
+    REQUIRE( std::floor( liquid_cold.temperature / 100000 ) == 276 );
+    REQUIRE( liquid_hot.has_flag( "HOT" ) );
+    REQUIRE( liquid_cold.has_flag( "COLD" ) );
+
+    SECTION( "liquids at the same temperature can stack together" ) {
+        CHECK( liquid_cold.stacks_with( liquid_cold ) );
+        CHECK( liquid_hot.stacks_with( liquid_hot ) );
+    }
+
+    SECTION( "liquids at different temperature do not stack" ) {
+        // Items with different flags do not stack
+        CHECK_FALSE( liquid_cold.stacks_with( liquid_hot ) );
+        CHECK_FALSE( liquid_hot.stacks_with( liquid_cold ) );
+    }
+
+    SECTION( "liquids at different temperature can be combined" ) {
+        CHECK( liquid_cold.combine( liquid_hot ) );
+        CHECK( liquid_hot.combine( liquid_cold ) );
+    }
+}
+
+
 static void assert_minimum_length_to_volume_ratio( const item &target )
 {
     if( target.type->get_id().is_null() ) {


### PR DESCRIPTION
This test case verifies that hot and cold liquids can be mixed with `item::combine`. You can use it to verify https://github.com/CleverRaven/Cataclysm-DDA/pull/44539 after you add a handler for liquids (since they won't pass `stacks_with`).

If you run these in the current version of your branch with `tests/cata_test [stack]`, you should see everything pass except "liquids at different temperatures can be combined":

```
../tests/item_test.cpp:196: FAILED:
  CHECK( liquid_cold.combine( liquid_hot ) )
with expansion:
  false

../tests/item_test.cpp:197: FAILED:
  CHECK( liquid_hot.combine( liquid_cold ) )
with expansion:
  false
```

If you don't mind, please go ahead and merge these into your branch for inclusion in your PR. Thanks!
